### PR TITLE
Add support for React 16

### DIFF
--- a/example/main.js
+++ b/example/main.js
@@ -3,10 +3,10 @@ const ReactDOM = require('react-dom');
 
 const NPSInput = require('../src');
 
-const Example = React.createClass({
+class Example extends React.Component {
     onSubmit({ score, commentText }) {
-        alert('Submitted ' + score + (commentText ? ' and comment "' + commentText + '"' : 'and no comment'));
-    },
+        alert('Submitted ' + score + (commentText ? ' and comment "' + commentText + '"' : ' and no comment'));
+    }
 
     render() {
         return (
@@ -15,7 +15,7 @@ const Example = React.createClass({
             </div>
         );
     }
-});
+}
 
 ReactDOM.render(
     <Example />,

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "mocha": "^3.2.0",
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
+    "proptypes": "^1.1.0",
     "yarn": "^1.3.2"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "mocha": "^3.2.0",
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
-    "proptypes": "^1.1.0",
+    "prop-types": "^15.6.2",
     "yarn": "^1.3.2"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "prepublish": "rm -rf ./lib && babel --out-dir ./lib ./src",
     "test": "npm run lint",
     "postpublish": "npm run deploy-example",
-    "build-example-js": "browserify ./example/main.js -o ./example/bundle.js -t [ babelify --presets [ es2015 react ] ]",
+    "build-example-js": "browserify ./example/main.js -o ./example/bundle.js -t [ babelify --presets [ es2015 react stage-0 ] ]",
     "build-example-css": "node-sass ./example/main.scss ./example/main.css",
     "build-example": "npm run build-example-js; npm run build-example-css",
     "serve-example": "live-server ./example/ --no-browser --port=8081",

--- a/src/NPSInput.js
+++ b/src/NPSInput.js
@@ -1,5 +1,5 @@
 const React = require('react');
-const PropTypes = require('proptypes')
+const PropTypes = require('prop-types');
 const classNames = require('classnames');
 const NPSScale = require('./NPSScale');
 

--- a/src/NPSInput.js
+++ b/src/NPSInput.js
@@ -7,15 +7,16 @@ const NPSScale = require('./NPSScale');
  * Promp the current user for its NPM score.
  * @param {ReactClass}
  */
-const NPSInput = React.createClass({
-    propTypes: {
+
+class NPSInput extends React.Component {
+    propTypes = {
         animated:    PropTypes.bool,
         comment:     PropTypes.bool,
         service:     PropTypes.string,
         onSubmit:    PropTypes.func.isRequired,
         onDismissed: PropTypes.func.isRequired,
         children:    PropTypes.func
-    },
+    }
 
     getDefaultProps() {
         return {
@@ -25,7 +26,7 @@ const NPSInput = React.createClass({
             onDismissed: () => {},
             children:    () => 'Thank you for your feedback!'
         };
-    },
+    }
 
     getInitialState() {
         return {
@@ -34,7 +35,7 @@ const NPSInput = React.createClass({
             score: null,
             commentText: null
         };
-    },
+    }
 
     /**
      * User clicked on a value.
@@ -49,7 +50,7 @@ const NPSInput = React.createClass({
         else {
             this.submit(score, null);
         }
-    },
+    }
 
     /**
      * User updated comment text.
@@ -58,7 +59,7 @@ const NPSInput = React.createClass({
         this.setState({
             commentText: event.target.value
         });
-    },
+    }
 
     /**
      * User submitted a form.
@@ -67,7 +68,7 @@ const NPSInput = React.createClass({
         const { score, commentText } = this.state;
         this.submit(score, commentText);
         event.preventDefault();
-    },
+    }
 
     /**
      * User clicked to dismiss this form.
@@ -81,7 +82,7 @@ const NPSInput = React.createClass({
         }, () => {
             onDismissed({ score, commentText });
         });
-    },
+    }
 
     submit(score, commentText) {
         const { onSubmit } = this.props;
@@ -92,7 +93,7 @@ const NPSInput = React.createClass({
         }, () => {
             onSubmit({ score, commentText });
         });
-    },
+    }
 
     render() {
         const { animated, comment, service, children } = this.props;
@@ -136,6 +137,6 @@ const NPSInput = React.createClass({
             </div>
         );
     }
-});
+}
 
 module.exports = NPSInput;

--- a/src/NPSInput.js
+++ b/src/NPSInput.js
@@ -1,4 +1,5 @@
 const React = require('react');
+const PropTypes = require('proptypes')
 const classNames = require('classnames');
 const NPSScale = require('./NPSScale');
 
@@ -8,12 +9,12 @@ const NPSScale = require('./NPSScale');
  */
 const NPSInput = React.createClass({
     propTypes: {
-        animated:    React.PropTypes.bool,
-        comment:     React.PropTypes.bool,
-        service:     React.PropTypes.string,
-        onSubmit:    React.PropTypes.func.isRequired,
-        onDismissed: React.PropTypes.func.isRequired,
-        children:    React.PropTypes.func
+        animated:    PropTypes.bool,
+        comment:     PropTypes.bool,
+        service:     PropTypes.string,
+        onSubmit:    PropTypes.func.isRequired,
+        onDismissed: PropTypes.func.isRequired,
+        children:    PropTypes.func
     },
 
     getDefaultProps() {

--- a/src/NPSInput.js
+++ b/src/NPSInput.js
@@ -9,7 +9,7 @@ const NPSScale = require('./NPSScale');
  */
 
 class NPSInput extends React.Component {
-    propTypes = {
+    static propTypes = {
         animated:    PropTypes.bool,
         comment:     PropTypes.bool,
         service:     PropTypes.string,
@@ -18,23 +18,30 @@ class NPSInput extends React.Component {
         children:    PropTypes.func
     }
 
-    getDefaultProps() {
-        return {
-            animated:    true,
-            comment:     false,
-            onSubmit:    () => {},
-            onDismissed: () => {},
-            children:    () => 'Thank you for your feedback!'
-        };
+    static defaultProps = {
+      animated: true,
+      comment: false,
+      onSubmit: () => {},
+      onDismissed: () => {},
+      onDismissed: () => {},
+      children: () => 'Thank you for your feedback!'
     }
 
-    getInitialState() {
-        return {
+    constructor(props) {
+        super(props)
+
+        this.state = {
             submitted: false,
             dismissed: false,
             score: null,
             commentText: null
-        };
+        }
+
+        this.onSelectScore = this.onSelectScore.bind(this)
+        this.onCommentUpdate = this.onCommentUpdate.bind(this)
+        this.onFormSubmit = this.onFormSubmit.bind(this)
+        this.onDismiss = this.onDismiss.bind(this)
+        this.submit = this.submit.bind(this)
     }
 
     /**

--- a/src/NPSScale.js
+++ b/src/NPSScale.js
@@ -1,4 +1,5 @@
 const React = require('react');
+const PropTypes = require('proptypes')
 const classNames = require('classnames');
 
 const MIN = 0;
@@ -10,8 +11,8 @@ const MAX = 10;
  */
 const NPSScale = React.createClass({
     propTypes: {
-        selectedValue: React.PropTypes.number,
-        onSubmit: React.PropTypes.func.isRequired
+        selectedValue: PropTypes.number,
+        onSubmit: PropTypes.func.isRequired
     },
 
     getDefaultProps() {

--- a/src/NPSScale.js
+++ b/src/NPSScale.js
@@ -9,40 +9,40 @@ const MAX = 10;
  * Scale to select NPS value.
  * @param {ReactClass}
  */
-const NPSScale = React.createClass({
-    propTypes: {
+class NPSScale extends React.Component {
+    static propTypes = {
         selectedValue: PropTypes.number,
         onSubmit: PropTypes.func.isRequired
-    },
+    }
 
     getDefaultProps() {
         return {
             onSubmit: (value) => {}
         };
-    },
+    }
 
     getInitialState() {
         return {
             value: null
         };
-    },
+    }
 
     onMouseEnter(value) {
         this.setState({
             value
         });
-    },
+    }
 
     onMouseLeave(value) {
         this.setState({
             value: null
         });
-    },
+    }
 
     onSelect(value) {
         const { onSubmit } = this.props;
         onSubmit(value);
-    },
+    }
 
     render() {
         const { value } = this.state;
@@ -76,7 +76,7 @@ const NPSScale = React.createClass({
             </div>
         );
     }
-});
+}
 
 function range(start, end) {
     return Array(end - start + 1).fill().map((_, idx) => start + idx);

--- a/src/NPSScale.js
+++ b/src/NPSScale.js
@@ -15,16 +15,16 @@ class NPSScale extends React.Component {
         onSubmit: PropTypes.func.isRequired
     }
 
-    getDefaultProps() {
-        return {
-            onSubmit: (value) => {}
-        };
+    static defaultProps = {
+      onSubmit: (value) => {}
     }
 
-    getInitialState() {
-        return {
+    constructor(props) {
+        super(props)
+
+        this.state = {
             value: null
-        };
+        }
     }
 
     onMouseEnter(value) {

--- a/src/NPSScale.js
+++ b/src/NPSScale.js
@@ -1,5 +1,5 @@
 const React = require('react');
-const PropTypes = require('proptypes')
+const PropTypes = require('prop-types');
 const classNames = require('classnames');
 
 const MIN = 0;


### PR DESCRIPTION
`react-nps-input` uses deprecated React routines like old-fashioned `React.PropTypes` and `React.createClass` which does not work with React 16. This pull request solves the problem and makes this module compatible with new React versions.